### PR TITLE
pdf侧边栏适配深色模式

### DIFF
--- a/resource/pdf/viewer.css
+++ b/resource/pdf/viewer.css
@@ -926,6 +926,12 @@ html[dir="rtl"] #outerContainer.sidebarOpen #sidebarContainer {
   width: 100%;
   background-color: #F7F7F7;
 }
+@media (prefers-color-scheme: dark) {
+
+  #sidebarContent {
+  background-color: #343434;
+  }
+}
 html[dir="ltr"] #sidebarContent {
   left: 0;
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.25);
@@ -3350,6 +3356,14 @@ a:focus > .thumbnail > .thumbnailSelectionRing {
      -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
+}
+
+@media (prefers-color-scheme: dark) {
+
+  #outlineView,
+  #attachmentsView {
+  background-color: #343434;
+  }
 }
 
 html[dir="ltr"] .treeWithDeepNesting > .treeItem,


### PR DESCRIPTION
issue  #90 
为 pdf 阅读器的侧边栏(sidebar)适配了深色模式
在深色模式下，侧边栏的背景变成深灰色(#343434)