### PR TITLE
pdf侧边栏 深色模式美化

### DIFF
--- a/resource/pdf/viewer.css
+++ b/resource/pdf/viewer.css
@@ -862,6 +862,13 @@ body::-webkit-scrollbar{width:4px!important;height:6px!important;}
   background-color: #F7F7F7;
 }
 
+@media (prefers-color-scheme: dark) {
+
+  .treeItems{
+    background-color: #343434;
+  }
+}
+
 
 #sidebarContainer {
   position: absolute;
@@ -3574,7 +3581,7 @@ html[dir="rtl"] .treeItemToggler::before {
 @media (prefers-color-scheme: dark) {
 
   .treeItem.selected {
-  background-color: rgba(255, 255, 255, 1);
+  background-color: rgba(40, 40, 40, 1);
   }
 }
 


### PR DESCRIPTION
issue #90 
request #91 
在提交深色模式后发现，侧边栏的outlineView模式下，部分元素没适配上深色模式。展开的目录 和 被选中的目录，还是浅色背景。
对这两项的背景颜色进行了修改。
展开的目录，背景色改为了 #343434
被选中的目录，背景色改为了更深的 #282828，即 rgb(40, 40, 40)