### PR TITLE
Adds missing keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,10 @@
 				"command": "office.html.preview",
 				"key": "ctrl+shift+v",
 				"when": "editorTextFocus && editorLangId == html"
+			},
+			{
+				"command": "office.markdown.switch",
+				"key": "ctrl+alt+e"
 			}
 		],
 		"menus": {


### PR DESCRIPTION
I believe that it adds a missing keybinding for button that allready works.
Keybinding is the same as described in readme.md

![t](https://github.com/cweijan/vscode-office/assets/146984890/98922fce-e554-4a7a-888a-6c308d997386)
