### PR TITLE
fix: Add Puppeteer sandbox args for Linux servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -377,6 +377,12 @@
 					"type": "string",
 					"description": "Set the chromium browser location for exporting markdown pdf."
 				},
+				"vscode-office.puppeteerArgs": {
+					"type": "array",
+					"items": { "type": "string" },
+					"default": [],
+					"description": "Additional arguments to pass to Puppeteer/Chromium when exporting PDF. Example: [\"--no-sandbox\", \"--disable-setuid-sandbox\"] for Linux servers running as root."
+				},
 				"vscode-office.pdfMarginTop": {
 					"type": "integer",
 					"default": 25,

--- a/src/service/markdown/html-export.js
+++ b/src/service/markdown/html-export.js
@@ -37,7 +37,8 @@ export async function exportByType(filePath, data, type, config) {
     let tmpfilename = path.join(isDev ? originPath.dir : os.tmpdir(), originPath.name + "_tmp.html")
     exportHtml(tmpfilename, data)
     let options = {
-        executablePath: config["executablePath"] || undefined
+        executablePath: config["executablePath"] || undefined,
+        args: config["puppeteerArgs"] || []
     }
 
     const puppeteer = require("puppeteer-core")

--- a/src/service/markdownService.ts
+++ b/src/service/markdownService.ts
@@ -49,6 +49,8 @@ export class MarkdownService {
             withoutOutline,
             // chromium path
             "executablePath": this.getChromiumPath(),
+            // puppeteer launch args (useful for Linux servers running as root)
+            "puppeteerArgs": this.getPuppeteerArgs(),
             // Set `true` to convert `\n` in paragraphs into `<br>`.
             "breaks": false,
             // pdf print option
@@ -58,14 +60,42 @@ export class MarkdownService {
         };
     }
 
+    private getPuppeteerArgs(): string[] {
+        // Custom args from settings
+        const customArgs = Global.getConfig<string[]>("puppeteerArgs");
+        if (customArgs && customArgs.length > 0) {
+            return customArgs;
+        }
+        // On Linux, running as root requires --no-sandbox
+        if (process.platform === 'linux') {
+            try {
+                const uid = typeof process.getuid === 'function' ? process.getuid() : -1;
+                if (uid === 0) {
+                    return ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'];
+                }
+            } catch {
+                // getuid not available on this platform
+            }
+        }
+        return [];
+    }
+
     private paths: string[] = [
+        // Windows
         "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
         "C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe",
         "C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe",
         join(homedir(), "AppData\\Local\\Microsoft\\Edge SxS\\Application\\msedge.exe"),
+        // macOS
         '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
         '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+        // Linux
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+        "/snap/bin/chromium",
         "/usr/bin/microsoft-edge",
     ]
 


### PR DESCRIPTION
## Problem
PDF export from Markdown fails on Linux servers (especially when using VS Code Remote SSH as root) with error:
```
TypeError: Cannot read properties of undefined (reading 'newPage')
```

This happens because Chromium requires `--no-sandbox` flag when running as root.

**Related: Partially fixes #426**

## Solution
- Add `puppeteerArgs` config option to pass custom arguments to Puppeteer
- Auto-detect Linux root user and add `--no-sandbox` flags automatically  
- Add common Linux Chromium paths: `/usr/bin/google-chrome`, `/usr/bin/chromium`, `/snap/bin/chromium`

## Changes
- `src/service/markdown/html-export.js` — pass args to puppeteer.launch()
- `src/service/markdownService.ts` — add getPuppeteerArgs() and Linux paths
- `package.json` — add `vscode-office.puppeteerArgs` setting

## Testing
Tested on Ubuntu 22.04 with Google Chrome and Chromium (snap) via VS Code Remote SSH as root.