### PR TITLE
feat: add dark mode toggle to Word and Excel viewers

### DIFF
--- a/src/react/view/excel/Excel.less
+++ b/src/react/view/excel/Excel.less
@@ -33,3 +33,45 @@
     }
 
 }
+
+/* ---- Dark mode toggle button ---- */
+.dark-mode-toggle {
+    position: fixed;
+    top: 10px;
+    right: 14px;
+    z-index: 1000;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(128, 128, 128, 0.4);
+    border-radius: 6px;
+    background-color: rgba(255, 255, 255, 0.85);
+    color: #2c3e50;
+    cursor: pointer;
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.06);
+    }
+}
+
+/* ---- Dark mode (black background, white text) ---- */
+body.office-dark {
+    background-color: #1a1a1a;
+
+    .excel-viewer {
+        background-color: #1a1a1a;
+    }
+
+    // Invert the spreadsheet canvas: white -> black, black text -> white.
+    #container {
+        filter: invert(1) hue-rotate(180deg);
+    }
+
+    .dark-mode-toggle {
+        background-color: rgba(40, 40, 40, 0.85);
+        color: #f0f0f0;
+        border-color: rgba(200, 200, 200, 0.3);
+    }
+}

--- a/src/react/view/excel/Excel.tsx
+++ b/src/react/view/excel/Excel.tsx
@@ -9,7 +9,16 @@ import Spreadsheet from './x-spreadsheet/index';
 
 export default function Excel() {
     const [loading, setLoading] = useState(true)
+    const [dark, setDark] = useState(() => {
+        try { return localStorage.getItem('office-dark-mode') === '1' } catch (e) { return false }
+    })
     const isCSV = useRef<boolean>(false)
+
+    useEffect(() => {
+        document.body.classList.toggle('office-dark', dark)
+        try { localStorage.setItem('office-dark-mode', dark ? '1' : '0') } catch (e) { }
+    }, [dark])
+
     useEffect(() => {
         const container = document.getElementById('container');
 
@@ -59,6 +68,11 @@ export default function Excel() {
         <div className='excel-viewer'>
             <Spin spinning={loading} fullscreen={true}>
             </Spin>
+            <button className="dark-mode-toggle" title="Toggle Dark Mode" onClick={() => setDark(d => !d)}>
+                <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M6.2 1.4a6.6 6.6 0 1 0 8.4 8.4A5.2 5.2 0 0 1 6.2 1.4z" fill="currentColor" />
+                </svg>
+            </button>
             <div id='container'></div>
             {
                 isCSV.current ? <VSCodeLogo /> : null

--- a/src/react/view/word/Word.css
+++ b/src/react/view/word/Word.css
@@ -18,3 +18,47 @@ body {
 .docx-wrapper>section.docx {
     max-width: 95vw;
 }
+
+/* ---- Dark mode toggle button ---- */
+.dark-mode-toggle {
+    position: fixed;
+    top: 10px;
+    right: 14px;
+    z-index: 1000;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(128, 128, 128, 0.4);
+    border-radius: 6px;
+    background-color: rgba(255, 255, 255, 0.85);
+    color: #2c3e50;
+    cursor: pointer;
+}
+
+.dark-mode-toggle:hover {
+    background-color: rgba(0, 0, 0, 0.06);
+}
+
+/* ---- Dark mode (black background, white text) ---- */
+body.office-dark {
+    background-color: #1a1a1a !important;
+}
+
+body.office-dark #container,
+body.office-dark .docx-wrapper {
+    background-color: #1a1a1a !important;
+}
+
+/* Invert the rendered page: white -> black, black text -> white.
+   hue-rotate keeps colored content (images, charts) looking natural. */
+body.office-dark .docx-wrapper>section.docx {
+    filter: invert(1) hue-rotate(180deg);
+}
+
+body.office-dark .dark-mode-toggle {
+    background-color: rgba(40, 40, 40, 0.85);
+    color: #f0f0f0;
+    border-color: rgba(200, 200, 200, 0.3);
+}

--- a/src/react/view/word/Word.tsx
+++ b/src/react/view/word/Word.tsx
@@ -7,7 +7,15 @@ import './Word.css';
 export default function Word() {
     const content = useRef(null), container = useRef(null)
     const [loading, setLoading] = useState(true)
+    const [dark, setDark] = useState(() => {
+        try { return localStorage.getItem('office-dark-mode') === '1' } catch (e) { return false }
+    })
     const [pageInfo, setPageInfo] = useState({ current: 1, total: 0, pageSize: null })
+
+    useEffect(() => {
+        document.body.classList.toggle('office-dark', dark)
+        try { localStorage.setItem('office-dark-mode', dark ? '1' : '0') } catch (e) { }
+    }, [dark])
 
     function updatePageInfo() {
         const pageSize = window.innerHeight - 85;
@@ -45,6 +53,11 @@ export default function Word() {
         <>
             <Spin spinning={loading} fullscreen={true}>
             </Spin>
+            <button className="dark-mode-toggle" title="Toggle Dark Mode" onClick={() => setDark(d => !d)}>
+                <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M6.2 1.4a6.6 6.6 0 1 0 8.4 8.4A5.2 5.2 0 0 1 6.2 1.4z" fill="currentColor" />
+                </svg>
+            </button>
             <div id="container">
                 <div id="content" style={{ width: '100%' }}>
                 </div>


### PR DESCRIPTION
## Summary
Adds an opt-in dark mode to Word and Excel viewers. Each viewer gets a moon-icon toggle button; the preference is persisted in `localStorage` so it sticks across files and reloads. Dark mode works by applying `filter: invert(1) hue-rotate(180deg)` to the rendered content, so a white page becomes black and black text becomes white, while the `hue-rotate` keeps images, charts, and other colored content looking natural rather than negative.

## Changes
- **Word** (`src/react/view/word/`): floating toggle button, invert filter on the `docx-preview` page sections.
- **Excel** (`src/react/view/excel/`): floating toggle button, invert filter on the x-spreadsheet canvas container.

They share the `office-dark` body class and the `office-dark-mode` localStorage key for consistent behavior.

Closes #360 