### PR TITLE
fix: standardize build script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -526,7 +526,7 @@
 		"build": "rm -rf out && vite build --mode=production",
 		"package": "vsce package --no-dependencies",
 		"publish": "vsce publish --no-dependencies && ovsx publish --no-dependencies",
-		"vscode:prepublish": "yarn run build"
+		"vscode:prepublish": "npm run build"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.0",


### PR DESCRIPTION
Replaces the yarn-specific build command with npm in the vscode:prepublish script to maintain consistency with the established npm-based build pipeline, avoiding potential execution failures in environments lacking yarn.