### PR TITLE
Improve RTL markdown rendering

### DIFF
--- a/resource/markdown/index.css
+++ b/resource/markdown/index.css
@@ -17,6 +17,115 @@ html {
     scrollbar-color: unset;
 }
 
+#vditor,
+.vditor-reset,
+.vditor-reset h1,
+.vditor-reset h2,
+.vditor-reset h3,
+.vditor-reset h4,
+.vditor-reset h5,
+.vditor-reset h6,
+.vditor-reset p,
+.vditor-reset li,
+.vditor-reset blockquote,
+.vditor-reset th,
+.vditor-reset td,
+.vditor-wysiwyg__block,
+.vditor-ir__node,
+#vditor [data-type="NodeParagraph"],
+#vditor [data-type="NodeListItem"],
+#vditor [data-type="NodeBlockquote"] {
+    direction: ltr;
+    text-align: left;
+    unicode-bidi: plaintext;
+}
+
+.vditor-reset p,
+.vditor-reset li,
+.vditor-reset blockquote,
+.vditor-reset th,
+.vditor-reset td,
+.vditor-wysiwyg__block,
+.vditor-ir__node,
+#vditor [data-type="NodeParagraph"],
+#vditor [data-type="NodeListItem"],
+#vditor [data-type="NodeBlockquote"] {
+    text-align: justify;
+    text-align-last: auto;
+    text-justify: inter-word;
+    overflow-wrap: anywhere;
+}
+
+#vditor .rtl-lang,
+#vditor [dir="rtl"] {
+    direction: rtl !important;
+    text-align: justify !important;
+    text-align-last: right !important;
+    unicode-bidi: plaintext !important;
+}
+
+#vditor h1.rtl-lang,
+#vditor h2.rtl-lang,
+#vditor h3.rtl-lang,
+#vditor h4.rtl-lang,
+#vditor h5.rtl-lang,
+#vditor h6.rtl-lang,
+#vditor h1[dir="rtl"],
+#vditor h2[dir="rtl"],
+#vditor h3[dir="rtl"],
+#vditor h4[dir="rtl"],
+#vditor h5[dir="rtl"],
+#vditor h6[dir="rtl"] {
+    text-align: right !important;
+}
+
+#vditor ul.rtl-lang,
+#vditor ol.rtl-lang,
+#vditor ul[dir="rtl"],
+#vditor ol[dir="rtl"],
+#vditor li.rtl-lang,
+#vditor li[dir="rtl"],
+#vditor [data-type="NodeList"].rtl-lang,
+#vditor [data-type="NodeList"][dir="rtl"],
+#vditor [data-type="NodeListItem"].rtl-lang,
+#vditor [data-type="NodeListItem"][dir="rtl"] {
+    direction: rtl !important;
+    text-align: justify !important;
+    padding-right: 2em !important;
+    padding-left: 0 !important;
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+    list-style-position: inside !important;
+}
+
+#vditor li.rtl-lang::marker,
+#vditor li[dir="rtl"]::marker {
+    direction: rtl !important;
+    unicode-bidi: isolate !important;
+    text-align: right !important;
+}
+
+#vditor .rtl-lang .vditor-wysiwyg__marker,
+#vditor .rtl-lang .vditor-ir__marker {
+    float: right !important;
+    margin-left: .35em !important;
+    margin-right: 0 !important;
+    direction: rtl !important;
+    text-align: right !important;
+    unicode-bidi: isolate !important;
+}
+
+.vditor-reset pre,
+.vditor-reset code,
+.vditor-reset .katex,
+.vditor-reset .vditor-mermaid-host,
+#vditor pre,
+#vditor code {
+    direction: ltr !important;
+    text-align: left !important;
+    unicode-bidi: isolate !important;
+}
+
 .vditor-context-menu {
     position: fixed;
     z-index: 10000;

--- a/resource/markdown/index.js
+++ b/resource/markdown/index.js
@@ -32,6 +32,88 @@ function normalizeEditMode(mode) {
   return mode === 'ir' ? 'ir' : 'wysiwyg'
 }
 
+const RTL_CHAR_RE = /[\u0590-\u08FF\uFB1D-\uFEFC]/
+const LTR_CHAR_RE = /[A-Za-z\u0400-\u052F]/
+const DIRECTION_BLOCK_SELECTOR = [
+  '#vditor .vditor-reset p',
+  '#vditor .vditor-reset li',
+  '#vditor .vditor-reset blockquote',
+  '#vditor .vditor-reset th',
+  '#vditor .vditor-reset td',
+  '#vditor .vditor-reset h1',
+  '#vditor .vditor-reset h2',
+  '#vditor .vditor-reset h3',
+  '#vditor .vditor-reset h4',
+  '#vditor .vditor-reset h5',
+  '#vditor .vditor-reset h6',
+  '#vditor .vditor-wysiwyg__block',
+  '#vditor .vditor-ir__node',
+  '#vditor [data-type="NodeParagraph"]',
+  '#vditor [data-type="NodeHeading"]',
+  '#vditor [data-type="NodeListItem"]',
+  '#vditor [data-type="NodeBlockquote"]',
+].join(',')
+const DIRECTION_LIST_SELECTOR = [
+  '#vditor .vditor-reset ul',
+  '#vditor .vditor-reset ol',
+  '#vditor [data-type="NodeList"]',
+].join(',')
+
+let directionObserver
+
+function firstStrongDirection(text) {
+  for (const char of text.trim()) {
+    if (RTL_CHAR_RE.test(char)) {
+      return 'rtl'
+    }
+    if (LTR_CHAR_RE.test(char)) {
+      return 'ltr'
+    }
+  }
+  return 'ltr'
+}
+
+function setDirection(element, direction) {
+  element.classList.toggle('rtl-lang', direction === 'rtl')
+  element.setAttribute('dir', direction)
+}
+
+function updateTextDirections() {
+  const target = document.getElementById('vditor')
+  if (!target) {
+    return
+  }
+  target.querySelectorAll(DIRECTION_BLOCK_SELECTOR).forEach((element) => {
+    if (!element.closest('pre, code, .katex, .vditor-mermaid-host')) {
+      setDirection(element, firstStrongDirection(element.textContent || ''))
+    }
+  })
+  target.querySelectorAll(DIRECTION_LIST_SELECTOR).forEach((list) => {
+    if (!list.closest('pre, code, .katex, .vditor-mermaid-host')) {
+      setDirection(list, list.querySelector('.rtl-lang') ? 'rtl' : firstStrongDirection(list.textContent || ''))
+    }
+  })
+}
+
+function scheduleTextDirections() {
+  requestAnimationFrame(updateTextDirections)
+  setTimeout(updateTextDirections, 100)
+  setTimeout(updateTextDirections, 500)
+}
+
+function watchTextDirections() {
+  const target = document.getElementById('vditor')
+  if (!target) {
+    return
+  }
+  directionObserver?.disconnect()
+  scheduleTextDirections()
+  directionObserver = new MutationObserver(scheduleTextDirections)
+  directionObserver.observe(target, { childList: true, characterData: true, subtree: true })
+}
+
+document.addEventListener('DOMContentLoaded', watchTextDirections)
+
 handler.on("open", async (md) => {
   const { config, language } = md;
   const codeMirrorTheme = normalizeCodeMirrorTheme(md.codeMirrorTheme ?? config.codeMirrorTheme)
@@ -101,9 +183,11 @@ handler.on("open", async (md) => {
     after() {
       handler.on("update", content => {
         editor.setValue(content);
+        scheduleTextDirections()
       })
       openLink()
       editor.restoreDocumentSession(true)
+      watchTextDirections()
     }
   })
   autoSymbol(handler, editor, config);


### PR DESCRIPTION
## Summary
- detect the first strong text direction for rendered Markdown blocks
- apply RTL classes and `dir` attributes to Arabic/Hebrew-script blocks and lists
- keep LTR text such as English and Russian left-to-right while preserving justified reading layout

## Why
Markdown files with RTL paragraphs were rendered with LTR list markers and alignment, making Arabic text difficult to read in the Office Viewer Markdown editor/preview.

## Validation
- `node --check resource/markdown/index.js`