### PR TITLE
fix: force UTF-8 output encoding for git commands (fixes garbled Chinese text in commit details panel)

### DIFF
--- a/src/gitHistory/service/gitExecutor.ts
+++ b/src/gitHistory/service/gitExecutor.ts
@@ -36,7 +36,10 @@ export class GitExecutor {
 
     spawn<T>(args: string[], repo: string, resolveValue: (stdout: string) => T): Promise<T> {
         return new Promise((resolve, reject) => {
-            const child = spawn(this.gitExecutable.path, args, {
+            // Force UTF-8 output encoding for all git commands to ensure non-ASCII
+            // characters (e.g. Chinese, Japanese, Korean) are not garbled on Windows
+            // systems where the locale encoding may differ from UTF-8.
+            const child = spawn(this.gitExecutable.path, ['-c', 'i18n.logOutputEncoding=utf-8', ...args], {
                 cwd: repo,
                 env: process.env,
             });


### PR DESCRIPTION
Closes #484

## Problem
On Windows with Chinese locale (zh-CN), git outputs non-ASCII characters in the system locale encoding (GBK/CP936). Node.js's `stdout.toString()` defaults to UTF-8, which misinterprets GBK-encoded bytes and produces garbled text (mojibake) in the commit details panel.

## Fix
Add `-c i18n.logOutputEncoding=utf-8` to all git commands spawned by `GitExecutor`. This forces git to encode all output in UTF-8, matching Node.js's default decoding.

## Affected commands
- `git show --quiet` (commit details body via %B)
- `git log` (commit list messages)
- `git diff --name-status` and `git diff --numstat` (file paths)
- `git branch`, `git remote`, `git config`, `git status`, etc.

The `-c` flag is a standard git config override that works on all platforms and is harmless for commands that don't produce text output.