### PR TITLE
feat: expandable code blocks in the Markdown editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Shortcuts: Based on [shortcut.md](shortcut.md), plus:
 - Move list down: `Ctrl Alt J` / `⌘ ^ J`
 - Edit in VS Code: `Ctrl Alt E` / `⌘ ^ E`
 
+Long code blocks are capped (default 400px) with an **expand/collapse** button to view them in full. Change the default height via the editor toolbar's ⚙ Settings → *Code block height* (down to compact, up to unlimited).
+
 ## Other features
 
 - HTML: live preview while editing; press `Ctrl+Shift+V` to open the live view

--- a/vditor/src/assets/less/_codemirror.less
+++ b/vditor/src/assets/less/_codemirror.less
@@ -45,7 +45,7 @@
     outline: none;
     flex: 1 1 auto;
     min-height: 1.35em;
-    max-height: 500px;
+    max-height: none;
     border-radius: 0 0 6px 6px;
     overflow: hidden;
     color: var(--cm-fg-color, var(--vscode-editor-foreground));
@@ -58,7 +58,7 @@
 
   .cm-scroller {
     overflow: auto;
-    max-height: 400px;
+    max-height: var(--cm-block-max-height, 400px);
     scrollbar-gutter: stable;
     font-family: inherit;
     line-height: calc(var(--vscode-editor-font-size, 13px) * 1.35);
@@ -232,6 +232,7 @@
 
   .vditor-cm-chrome__delete,
   .vditor-cm-chrome__copy,
+  .vditor-cm-chrome__expand,
   .vditor-cm-chrome__theme-trigger {
     opacity: 0;
     visibility: hidden;
@@ -389,7 +390,8 @@
   pointer-events: auto;
 }
 
-.vditor-cm-chrome__theme-trigger {
+.vditor-cm-chrome__theme-trigger,
+.vditor-cm-chrome__expand {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -928,7 +930,7 @@
   .cm-editor {
     outline: none;
     min-height: 2em;
-    max-height: 400px;
+    max-height: var(--cm-block-max-height, 400px);
     border-radius: 6px;
     color: var(--cm-fg-color, var(--vscode-editor-foreground));
   }
@@ -1056,4 +1058,33 @@
   }
 
   // Keep preview's original display so KaTeX/min-height doesn't affect line box unexpectedly.
+}
+
+// Expandable code block: lift the height cap for a single block
+.vditor-cm-host--expanded .cm-editor,
+.vditor-cm-host--expanded .cm-scroller {
+  max-height: none;
+}
+
+// Expand/collapse toggle: base look + behaviour (incl. pointer-events:auto) are shared with
+// .vditor-cm-chrome__theme-trigger above. Here we add the icon, and the visibility: like the
+// other chrome buttons it appears on hover/focus, additionally gated to blocks that overflow.
+.vditor-cm-chrome__expand-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--cm-fg-color, var(--toolbar-icon-color));
+
+  .codicon {
+    font-size: 16px;
+    line-height: 1;
+  }
+}
+
+.vditor-cm-host--has-overflow:hover .vditor-cm-chrome__expand,
+.vditor-cm-host--has-overflow:has(.cm-editor.cm-focused) .vditor-cm-chrome__expand {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }

--- a/vditor/src/js/i18n/en_US.js
+++ b/vditor/src/js/i18n/en_US.js
@@ -1,4 +1,7 @@
 window.VditorI18n = {
+  'codeBlockHeight': 'Code block height',
+  'expandCode': 'Expand',
+  'collapseCode': 'Collapse',
   'alignCenter': 'Center',
   'alignLeft': 'Left',
   'alignRight': 'Right',

--- a/vditor/src/js/i18n/ja_JP.js
+++ b/vditor/src/js/i18n/ja_JP.js
@@ -1,4 +1,7 @@
 window.VditorI18n = {
+  'codeBlockHeight': 'コードブロックの高さ',
+  'expandCode': '展開',
+  'collapseCode': '折りたたむ',
   'alignCenter': '中央',
   'alignLeft': '左側',
   'alignRight': '右側',

--- a/vditor/src/js/i18n/ko_KR.js
+++ b/vditor/src/js/i18n/ko_KR.js
@@ -1,4 +1,7 @@
 window.VditorI18n = {
+  'codeBlockHeight': '코드 블록 높이',
+  'expandCode': '펼치기',
+  'collapseCode': '접기',
   'alignCenter': '가운데',
   'alignLeft': '왼쪽',
   'alignRight': '오른쪽',

--- a/vditor/src/js/i18n/ru_RU.js
+++ b/vditor/src/js/i18n/ru_RU.js
@@ -1,4 +1,7 @@
 window.VditorI18n = {
+  'codeBlockHeight': 'Высота блока кода',
+  'expandCode': 'Развернуть',
+  'collapseCode': 'Свернуть',
   'alignCenter': 'Выровнять по центру',
   'alignLeft': 'Выровнять по левому краю',
   'alignRight': 'Выровнять по правому краю',

--- a/vditor/src/js/i18n/zh_CN.js
+++ b/vditor/src/js/i18n/zh_CN.js
@@ -1,4 +1,7 @@
 window.VditorI18n = {
+  'codeBlockHeight': '代码块高度',
+  'expandCode': '展开',
+  'collapseCode': '收起',
   'alignCenter': '居中',
   'alignLeft': '居左',
   'alignRight': '居右',

--- a/vditor/src/js/i18n/zh_TW.js
+++ b/vditor/src/js/i18n/zh_TW.js
@@ -1,4 +1,7 @@
 window.VditorI18n = {
+  'codeBlockHeight': '程式碼區塊高度',
+  'expandCode': '展開',
+  'collapseCode': '收合',
   'alignCenter': '置中',
   'alignLeft': '置左',
   'alignRight': '置右',

--- a/vditor/src/ts/codeBlock/codeBlockChrome.ts
+++ b/vditor/src/ts/codeBlock/codeBlockChrome.ts
@@ -27,6 +27,9 @@ import {
 
 const CHROME_CLASS = "vditor-cm-chrome";
 const LANG_SEARCH_CLASS = "vditor-cm-chrome__lang-search";
+const EXPANDED_CLASS = "vditor-cm-host--expanded";
+const HAS_OVERFLOW_CLASS = "vditor-cm-host--has-overflow";
+const OVERFLOW_THRESHOLD = 8;
 
 export const isInsideCodeBlockChrome = (target: EventTarget | Node | null) => {
     if (!target) {
@@ -58,6 +61,8 @@ interface ICodeBlockChrome {
     langReadonly: boolean;
     performCopy: () => Promise<boolean>;
     langActiveIndex: number;
+    expandBtn: HTMLButtonElement;
+    resizeObserver?: ResizeObserver;
 }
 
 const chromeMap = new WeakMap<HTMLElement, ICodeBlockChrome>();
@@ -525,12 +530,20 @@ const createChromeRoot = (editable: boolean) => {
         actions.appendChild(deleteBtn);
     }
 
+    const expandBtn = document.createElement("button");
+    expandBtn.type = "button";
+    expandBtn.className = "vditor-cm-chrome__expand";
+    expandBtn.setAttribute("aria-label", window.VditorI18n.expandCode || "Expand");
+    expandBtn.setAttribute("aria-expanded", "false");
+    expandBtn.innerHTML = `<span class="vditor-cm-chrome__expand-icon">${codicon("chevron-down")}</span>`;
+
     const copyBtn = document.createElement("button");
     copyBtn.type = "button";
     copyBtn.className = "vditor-cm-chrome__copy";
     copyBtn.setAttribute("aria-label", window.VditorI18n.copy || "Copy");
     copyBtn.innerHTML = `<span class="vditor-cm-chrome__copy-icon">${codicon("copy")}</span>`;
     actions.appendChild(copyBtn);
+    actions.appendChild(expandBtn);
 
     toolbar.appendChild(langWrap);
     toolbar.appendChild(actions);
@@ -546,6 +559,7 @@ const createChromeRoot = (editable: boolean) => {
         toolbar,
         deleteBtn,
         copyBtn,
+        expandBtn,
         langWrap,
         langTrigger,
         langLabel: langTrigger.querySelector(".vditor-cm-chrome__lang-label") as HTMLElement,
@@ -557,6 +571,51 @@ const createChromeRoot = (editable: boolean) => {
         themeTrigger,
         themePanel,
     };
+};
+
+const updateExpandButton = (chrome: ICodeBlockChrome, host: HTMLElement) => {
+    const expanded = host.classList.contains(EXPANDED_CLASS);
+    chrome.expandBtn.setAttribute(
+        "aria-label",
+        expanded ? (window.VditorI18n.collapseCode || "Collapse") : (window.VditorI18n.expandCode || "Expand"),
+    );
+    chrome.expandBtn.setAttribute("aria-expanded", String(expanded));
+    const icon = chrome.expandBtn.querySelector(".vditor-cm-chrome__expand-icon .codicon") as HTMLElement | null;
+    if (icon) {
+        icon.classList.toggle("codicon-chevron-down", !expanded);
+        icon.classList.toggle("codicon-chevron-up", expanded);
+    }
+};
+
+const recomputeExpandState = (chrome: ICodeBlockChrome, host: HTMLElement) => {
+    const scroller = host.querySelector(".cm-scroller") as HTMLElement | null;
+    const expanded = host.classList.contains(EXPANDED_CLASS);
+    const overflowing = !!scroller && scroller.scrollHeight - scroller.clientHeight > OVERFLOW_THRESHOLD;
+    host.classList.toggle(HAS_OVERFLOW_CLASS, expanded || overflowing);
+    updateExpandButton(chrome, host);
+};
+
+const setupExpandToggle = (chrome: ICodeBlockChrome, host: HTMLElement) => {
+    const btn = chrome.expandBtn;
+    if (btn.dataset.expandBound !== "true") {
+        btn.dataset.expandBound = "true";
+        btn.addEventListener("mousedown", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+        });
+        btn.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            host.classList.toggle(EXPANDED_CLASS);
+            recomputeExpandState(chrome, host);
+        });
+        const content = host.querySelector(".cm-content");
+        if (typeof ResizeObserver !== "undefined" && content) {
+            chrome.resizeObserver = new ResizeObserver(() => recomputeExpandState(chrome, host));
+            chrome.resizeObserver.observe(content);
+        }
+    }
+    recomputeExpandState(chrome, host);
 };
 
 export const ensurePreviewCodeBlockChrome = (
@@ -582,6 +641,7 @@ export const ensurePreviewCodeBlockChrome = (
     chromeMap.set(host, chrome);
     host.insertBefore(chrome.root, host.firstChild);
     bindCopyButton(chrome.copyBtn, () => chrome.performCopy());
+    setupExpandToggle(chrome, host);
     updateCodeBlockChromeLanguage(host, languageName);
 };
 
@@ -664,6 +724,7 @@ export const ensureCodeBlockChrome = (
             });
             bindThemePanel(vditor, chrome);
         }
+        setupExpandToggle(chrome, host);
     }
 
     chrome.performCopy = options.performCopy;
@@ -673,6 +734,7 @@ export const ensureCodeBlockChrome = (
     const codeElement = blockElement.querySelector("pre code") as HTMLElement;
     const languageName = isMathBlockElement(blockElement) ? "math" : (codeElement ? getCodeLanguageName(codeElement) : "");
     updateCodeBlockChromeLanguage(blockElement, languageName);
+    recomputeExpandState(chrome, host);
 };
 
 export const removeCodeBlockChrome = (target: HTMLElement) => {
@@ -686,6 +748,7 @@ export const removeCodeBlockChrome = (target: HTMLElement) => {
     if (openThemeChrome === chrome) {
         closeThemePanel();
     }
+    chrome.resizeObserver?.disconnect();
     chrome.root.remove();
     chromeMap.delete(target);
 };

--- a/vditor/src/ts/toolbar/Settings.ts
+++ b/vditor/src/ts/toolbar/Settings.ts
@@ -32,6 +32,9 @@ import {
     IMAGE_MAX_WIDTH_MAX,
     IMAGE_MAX_HEIGHT_MIN,
     IMAGE_MAX_HEIGHT_MAX,
+    CODE_BLOCK_MAX_HEIGHT_KEY,
+    CODE_BLOCK_MAX_HEIGHT_DEFAULT,
+    CODE_BLOCK_MAX_HEIGHT_OPTIONS,
     getGlobalLocalStorageSetting,
     setGlobalLocalStorageSetting,
     resetGlobalSettings,
@@ -43,6 +46,7 @@ const DROPDOWN_OPTIONS_MAP: Record<string, readonly { label: string; value: stri
     [FONT_FAMILY_KEY]: FONT_FAMILY_OPTIONS,
     [BOLD_COLOR_KEY]: BOLD_COLOR_OPTIONS,
     [PAGE_WIDTH_KEY]: PAGE_WIDTH_OPTIONS,
+    [CODE_BLOCK_MAX_HEIGHT_KEY]: CODE_BLOCK_MAX_HEIGHT_OPTIONS,
 };
 
 export class Settings extends MenuItem {
@@ -117,6 +121,10 @@ export class Settings extends MenuItem {
             else if (key === PAGE_WIDTH_KEY) {
                 if (value === "100%") vditor.element.style.removeProperty("--vditor-page-width");
                 else vditor.element.style.setProperty("--vditor-page-width", value);
+            }
+            else if (key === CODE_BLOCK_MAX_HEIGHT_KEY) {
+                if (value === CODE_BLOCK_MAX_HEIGHT_DEFAULT) vditor.element.style.removeProperty("--cm-block-max-height");
+                else vditor.element.style.setProperty("--cm-block-max-height", value);
             }
             // update trigger label
             const trigger = panelElement.querySelector(`[data-dropdown-key="${key}"]`) as HTMLElement | null;

--- a/vditor/src/ts/ui/settingsPanel.ts
+++ b/vditor/src/ts/ui/settingsPanel.ts
@@ -18,6 +18,9 @@ import {
     IMAGE_MAX_HEIGHT_KEY,
     IMAGE_MAX_WIDTH_DEFAULT,
     IMAGE_MAX_HEIGHT_DEFAULT,
+    CODE_BLOCK_MAX_HEIGHT_KEY,
+    CODE_BLOCK_MAX_HEIGHT_DEFAULT,
+    CODE_BLOCK_MAX_HEIGHT_OPTIONS,
     getAIPrompts,
     setAIPrompts,
     AIPrompt,
@@ -239,6 +242,7 @@ export const buildSettingsPanelHTML = (vditor: IVditor) => {
     const pageWidth = getGlobalLocalStorageSetting<string>(PAGE_WIDTH_KEY, PAGE_WIDTH_DEFAULT) ?? PAGE_WIDTH_DEFAULT;
     const imgMaxWidth = getGlobalLocalStorageSetting<number>(IMAGE_MAX_WIDTH_KEY, IMAGE_MAX_WIDTH_DEFAULT);
     const imgMaxHeight = getGlobalLocalStorageSetting<number>(IMAGE_MAX_HEIGHT_KEY, IMAGE_MAX_HEIGHT_DEFAULT);
+    const codeBlockMaxHeight = getGlobalLocalStorageSetting<string>(CODE_BLOCK_MAX_HEIGHT_KEY, CODE_BLOCK_MAX_HEIGHT_DEFAULT) ?? CODE_BLOCK_MAX_HEIGHT_DEFAULT;
     return `<div class="${SETTINGS_PANEL_CLASS}">
         <div class="${SETTINGS_PANEL_CLASS}__section">
             <div class="${SETTINGS_PANEL_CLASS}__title">Edit Mode</div>
@@ -257,6 +261,7 @@ export const buildSettingsPanelHTML = (vditor: IVditor) => {
                 ${buildDropdownHTML(FONT_FAMILY_KEY, "Font", FONT_FAMILY_OPTIONS, fontFamily)}
                 ${buildDropdownHTML(BOLD_COLOR_KEY, "Bold", BOLD_COLOR_OPTIONS, boldColor)}
                 ${buildDropdownHTML(PAGE_WIDTH_KEY, i18n.pageWidth, PAGE_WIDTH_OPTIONS, pageWidth)}
+                ${buildDropdownHTML(CODE_BLOCK_MAX_HEIGHT_KEY, i18n.codeBlockHeight, CODE_BLOCK_MAX_HEIGHT_OPTIONS, codeBlockMaxHeight)}
                 ${buildLineHeightStepperHTML(lineHeight)}
             </div>
         </div>

--- a/vditor/src/ts/util/globalLocalStorageSettings.ts
+++ b/vditor/src/ts/util/globalLocalStorageSettings.ts
@@ -98,6 +98,17 @@ export const PAGE_WIDTH_OPTIONS = [
     { label: "960px", value: "960px" },
 ] as const;
 
+export const CODE_BLOCK_MAX_HEIGHT_KEY = "codeBlockMaxHeight";
+export const CODE_BLOCK_MAX_HEIGHT_DEFAULT = "400px";
+
+export const CODE_BLOCK_MAX_HEIGHT_OPTIONS = [
+    { label: "Compact (300px)", value: "300px" },
+    { label: "Default (400px)", value: "400px" },
+    { label: "Tall (600px)", value: "600px" },
+    { label: "Taller (800px)", value: "800px" },
+    { label: "Unlimited", value: "none" },
+] as const;
+
 export const IMAGE_MAX_WIDTH_KEY = "imageMaxWidth";
 export const IMAGE_MAX_HEIGHT_KEY = "imageMaxHeight";
 export const IMAGE_MAX_WIDTH_DEFAULT = 100;
@@ -195,6 +206,12 @@ export const applyEditorSettings = (vditorElement: HTMLElement) => {
     }
     if (imgMaxWidth !== undefined) vditorElement.style.setProperty("--vditor-image-max-width", `${imgMaxWidth}%`);
     if (imgMaxHeight !== undefined) vditorElement.style.setProperty("--vditor-image-max-height", `${imgMaxHeight}vh`);
+    const codeBlockMaxHeight = getGlobalLocalStorageSetting<string>(CODE_BLOCK_MAX_HEIGHT_KEY);
+    if (codeBlockMaxHeight !== undefined && codeBlockMaxHeight !== CODE_BLOCK_MAX_HEIGHT_DEFAULT) {
+        vditorElement.style.setProperty("--cm-block-max-height", codeBlockMaxHeight);
+    } else {
+        vditorElement.style.removeProperty("--cm-block-max-height");
+    }
 
 };
 


### PR DESCRIPTION
## Problem

Long code blocks in the Markdown WYSIWYG editor are capped at a fixed height (~400px) with an inner scrollbar, so a tall code block can't be viewed in full — you can only scroll inside it.

## Changes

- **Per-block expand/collapse button** in the code block's chrome toolbar. It appears only when the block actually overflows (a `ResizeObserver` watches the content), and clicking it lifts the height cap for that block (toggles a `vditor-cm-host--expanded` class); clicking again collapses it. The button reuses the existing chrome-button styling for visual consistency.
- **"Code block height" control** in the editor ⚙ Settings panel: `Compact (300px) / Default (400px) / Tall (600px) / 800px / Unlimited`, persisted in localStorage through the existing `applyEditorSettings` path (same mechanism as image max-width/height, page width, etc.).

## Implementation

- The hard-coded `max-height` in `vditor/src/assets/less/_codemirror.less` becomes a single CSS variable `--cm-block-max-height` (default `400px`). Math blocks share the same variable; read-only preview hosts already render at full height, so they're unaffected.
- i18n strings added for `en_US`, `zh_CN`, `zh_TW`, `ja_JP`, `ko_KR`, `ru_RU`.

## Notes

- Default behavior is unchanged (still 400px) — fully backward compatible.
- No extension-host changes and no new VS Code setting; the control lives in the editor's settings panel.
- No built artifacts committed (`dist/` is gitignored).
