### PR TITLE
Fix markdown relative images in remote webviews

### DIFF
--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -81,6 +81,8 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             enableScripts: true,
             localResourceRoots: [
                 ...getExtensionResourceRoots(this.context),
+                folderPath,
+                ...(vscode.workspace.workspaceFolders?.map(folder => folder.uri) ?? []),
                 vscode.Uri.file("/"),
                 ...this.getFolders(),
             ],


### PR DESCRIPTION
## Summary

Fix broken relative Markdown images in Remote SSH webviews.

In Remote SSH environments such as Cursor or VS Code, Markdown files such as:

```markdown
![img](./image.png)
```

may render as broken images in Office Viewer, while the same file works locally.

## Cause

The Markdown editor webview did not include the current Markdown document folder or workspace folders in `localResourceRoots`.

In a remote workspace, relative images may resolve to remote workspace URIs, so the webview may not be allowed to load them.

## Why this matters

This affects users who open Markdown files from a remote workspace, where image resources are not regular local `file:` URIs from the UI host.

## Change

Add the current Markdown document folder and workspace folders to `localResourceRoots`.

This keeps the existing local Linux/macOS/Windows behavior and does not change Markdown path parsing or configuration behavior.

## Verification

- Built successfully with Node 20.19.0.
- Packaged VSIX successfully.
- Installed the generated VSIX in Cursor.
- Verified that `![img](./image.png)` renders correctly in a Remote SSH workspace.