### PR TITLE
feat: add option to disable custom viewer for DOCX in Git diff/history views

### DIFF
--- a/package.json
+++ b/package.json
@@ -760,6 +760,17 @@
 				}
 			},
 			{
+				"title": "Git",
+				"order": 4,
+				"properties": {
+					"vscode-office.disableDocxDiffHistoryPreview": {
+						"type": "boolean",
+						"default": true,
+						"description": "Disable the custom office viewer for DOCX Git diff/history views to use VS Code's default diff editor."
+					}
+				}
+			},
+			{
 				"title": "Telemetry",
 				"order": 99,
 				"properties": {

--- a/src/provider/officeViewerProvider.ts
+++ b/src/provider/officeViewerProvider.ts
@@ -27,8 +27,23 @@ export class OfficeViewerProvider implements vscode.CustomReadonlyEditorProvider
 	public openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext, token: vscode.CancellationToken): vscode.CustomDocument | Thenable<vscode.CustomDocument> {
 		return { uri, dispose: (): void => { } };
 	}
-	public resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken): void | Thenable<void> {
+	public async resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken): Promise<void> {
 		const uri = document.uri;
+		const suffix = getFileSuffix(uri.fsPath);
+		const isDocx = ['.docx', '.dotx'].includes(suffix);
+		if (isDocx) {
+			const disableDocxDiffHistoryPreview = vscode.workspace.getConfiguration('vscode-office').get<boolean>('disableDocxDiffHistoryPreview', true);
+			if (disableDocxDiffHistoryPreview) {
+				const isDiff = ['git', 'gitlens', 'gitlens-git', 'vscode-local-history', 'review'].includes(uri.scheme);
+				if (isDiff) {
+					// Delay to let VS Code finish setting up the diff tab
+					setTimeout(() => {
+						vscode.commands.executeCommand('workbench.action.reopenTextEditor');
+					}, 300);
+					return;
+				}
+			}
+		}
 		const webview = webviewPanel.webview;
 		const folderPath = vscode.Uri.joinPath(uri, '..');
 		webview.options = {
@@ -39,7 +54,6 @@ export class OfficeViewerProvider implements vscode.CustomReadonlyEditorProvider
 		const handler = Handler.bind(webviewPanel, uri);
 
 		let route: string;
-		const suffix = getFileSuffix(uri.fsPath);
 		const isSvg = /\.svg$/i.test(suffix);
 		handleCommonEvent(uri, handler, isSvg ? { skipOpen: true } : undefined);
 		if (isSvg) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
 	"exclude": [
 		"src/react",
 		"node_modules",
-		".vscode-test"
+		".vscode-test",
+		"vditor"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
 	"exclude": [
 		"src/react",
 		"node_modules",
-		".vscode-test",
-		"vditor"
+		".vscode-test"
 	]
 }


### PR DESCRIPTION
This PR adds a new setting vscode-office.disableDocxDiffHistoryPreview (default: true) that automatically falls back to VS Code's built-in text diff editor for DOCX files in Git diff/history views, while keeping the custom Office Viewer for normal file editing.

<img width="567" height="197" alt="PixPin_2026-06-28_16-35-01" src="https://github.com/user-attachments/assets/d858ac44-bd6d-4644-8c38-97adbe8214b7" />
<img width="574" height="227" alt="PixPin_2026-06-28_16-35-29" src="https://github.com/user-attachments/assets/cc7132e7-8f26-4383-9ab6-cdbf580403ec" />

related: https://github.com/cweijan/vscode-office/issues/392