### PR TITLE
fix(markdown): drop vditor focusHost 'vscode' to fix cursor stuck after browser reconnect

### DIFF
--- a/resource/markdown/index.js
+++ b/resource/markdown/index.js
@@ -20,7 +20,7 @@ handler.on("open", async (md) => {
     cache: {
       enable: false,
       id: documentCacheId,
-      focusHost: 'vscode',
+      focusHost: 'browser',
     },
     mode: editMode,
     editorTheme,


### PR DESCRIPTION
## Problem

After opening a markdown file with the vscode-office custom editor and closing the browser (without closing the markdown tab first), the next time the browser is opened the markdown auto-loads but the cursor blinks without accepting any clicks. Clicking inside the markdown, on the toolbar, or on the terminal panel all fail to register. Workaround is to manually close and reopen the markdown tab.

Affects web (code-server / browser) only. Electron desktop build is unaffected.

## Root cause

`resource/markdown/index.js` sets `focusHost: 'vscode'` on Vditor. With this flag, Vditor registers three global listeners on the webview iframe window:

```js
window.addEventListener('blur',  () => rQ(e))
window.addEventListener('focus', () => Xhe || Yhe || iQ)
document.addEventListener('visibilitychange', ...)
```

On browser reconnect the iframe is destroyed and recreated. The new iframe triggers `editor.restoreDocumentSession(true)` → `iQ(e, {onLoad: true})`. With `cache.enable: false` there is no localStorage cache and the WeakMap cache is per-page-load, so `XZ(e)` returns null. The function then takes the `if (!r) { tQ(e, null), nQ(e); return }` branch, which pins focus to a non-existent selection. The iframe is `activeElement` (cursor blinks) but no DOM element holds focus, so all subsequent clicks fail. Clicking on the terminal panel also fails because the `window.blur` listener runs synchronously and interferes with the focusin event.

Because `cache.enable: false` was never changed, there has never been a cache to restore across sessions — the `'vscode'` mode was dangling from the start.

## Reproduction

1. Open code-server (or any web-hosted VS Code) with this extension installed
2. Open a `.md` file (uses `cweijan.markdownViewer` custom editor)
3. Close the browser tab without closing the markdown tab first
4. Reopen the browser and reconnect — markdown auto-loads
5. Cursor blinks; clicks do not register; clicking on the terminal panel also fails
6. Manually close and reopen the markdown tab — issue resolves

## Fix

Change `focusHost: 'vscode'` to `focusHost: 'browser'`. With `'browser'` mode, the three global listeners are not registered; focus transitions go through the browser default route and clicks work normally. `cache.enable: false` is preserved (no functional regression for in-memory state during a session).

## Testing

Verified on code-server 4.x with this extension at v4.1.5. After the change the close-reopen scenario works without the cursor getting stuck. No regression observed in: opening markdown, clicking outline items, switching WYSIWYG ↔ IR via `Ctrl+Alt+E`, toolbar interactions, file save, image paste.
Closes #538