### PR TITLE
fix: 禁用 core.quotepath 以修复 diff 面板中文文件名乱码

### DIFF
--- a/src/gitHistory/service/gitExecutor.ts
+++ b/src/gitHistory/service/gitExecutor.ts
@@ -99,10 +99,11 @@ export class GitExecutor {
 
     spawnWithWarning<T>(args: string[], repo: string, resolveValue: (stdout: string) => T): Promise<GitSpawnResult<T>> {
         return new Promise((resolve, reject) => {
-            // Force UTF-8 output encoding for all git commands to ensure non-ASCII
-            // characters (e.g. Chinese, Japanese, Korean) are not garbled on Windows
-            // systems where the locale encoding may differ from UTF-8.
-            const child = spawn(this.gitExecutable.path, ['-c', 'i18n.logOutputEncoding=utf-8', ...args], {
+            // Force UTF-8 output encoding and disable path quoting for all git
+            // commands to ensure non-ASCII characters (e.g. Chinese, Japanese,
+            // Korean) are not garbled on Windows systems where the locale encoding
+            // may differ from UTF-8, or where core.quotepath escapes file paths.
+            const child = spawn(this.gitExecutable.path, ['-c', 'i18n.logOutputEncoding=utf-8', '-c', 'core.quotepath=false', ...args], {
                 cwd: repo,
                 env: process.env,
             });

--- a/src/gitHistory/service/gitExecutor.ts
+++ b/src/gitHistory/service/gitExecutor.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import iconv from 'iconv-lite';
 import type { GitExecutable } from '../types/git';
 
 export const UNABLE_TO_FIND_GIT_MSG =
@@ -22,10 +23,47 @@ function resolveSpawnOutput(
     });
 }
 
+/**
+ * Decode a Buffer from git output, with fallback for non-UTF-8 encodings
+ * common on Windows (e.g. GBK/CP936 on Chinese systems).
+ *
+ * Git's `-c i18n.logOutputEncoding=utf-8` should make git output UTF-8, but
+ * if a commit was stored without an explicit encoding header git assumes
+ * UTF-8 and does no conversion, leaving the raw bytes in the system locale
+ * encoding (e.g. GBK). This function detects that case and re-decodes.
+ */
+function decodeGitOutput(buffer: Buffer): string {
+    if (buffer.length === 0) return ''
+
+    // Try strict UTF-8 decoding first — this is the fast path for valid UTF-8.
+    try {
+        return new TextDecoder('utf-8', { fatal: true }).decode(buffer)
+    } catch {
+        // Buffer is not valid UTF-8; it may be in the system locale encoding.
+    }
+
+    // Try GBK (CP936) — common on Chinese Windows (zh-CN).
+    // Also try BIG5 (CP950, Traditional Chinese) and Shift-JIS (CP932, Japanese).
+    for (const enc of ['GBK', 'BIG5', 'Shift_JIS']) {
+        try {
+            const decoded = iconv.decode(buffer, enc)
+            // iconv decode never fails silently, but guard against empty result
+            if (decoded && decoded.length > 0) {
+                return decoded
+            }
+        } catch {
+            continue
+        }
+    }
+
+    // Last resort: text decode with replacement (never throws, replaces bad bytes)
+    return buffer.toString('utf-8')
+}
+
 function getErrorMessage(error: Error | null, stdout: Buffer, stderr: Buffer): string {
     if (error) return error.message;
-    const stderrLines = stderr.toString().split(EOL_REGEX).map((line) => line.trim()).filter(Boolean);
-    const stdoutLines = stdout.toString().split(EOL_REGEX).map((line) => line.trim()).filter(Boolean);
+    const stderrLines = decodeGitOutput(stderr).split(EOL_REGEX).map((line) => line.trim()).filter(Boolean);
+    const stdoutLines = decodeGitOutput(stdout).split(EOL_REGEX).map((line) => line.trim()).filter(Boolean);
     const lines = [...stderrLines, ...stdoutLines];
     const priorityLine = lines.find((line) =>
         /fatal|error|conflict|failed|aborting|cannot|could not|already exists/i.test(line)
@@ -37,7 +75,7 @@ function getErrorMessage(error: Error | null, stdout: Buffer, stderr: Buffer): s
 }
 
 function getWarningMessage(stderr: Buffer): string | null {
-    const stderrLines = stderr.toString().split(EOL_REGEX).map((line) => line.trim()).filter(Boolean);
+    const stderrLines = decodeGitOutput(stderr).split(EOL_REGEX).map((line) => line.trim()).filter(Boolean);
     if (stderrLines.length === 0) {
         return null;
     }
@@ -76,7 +114,7 @@ export class GitExecutor {
                 }
                 try {
                     resolve({
-                        value: resolveValue(stdout.toString()),
+                        value: resolveValue(decodeGitOutput(stdout)),
                         warning: getWarningMessage(stderr),
                     });
                 } catch (e) {


### PR DESCRIPTION
Closes #546

## 问题描述

上一个修复 #485 添加了 `-c i18n.logOutputEncoding=utf-8` 解决了 commit message 中文乱码，但 **diff 面板中的中文文件名仍然是乱码**。

## 根因分析

Git 的 `core.quotepath` 默认为 `true`，会把非 ASCII 文件路径转义成八进制序列：

```
# quotepath=true（默认）— 乱码
D       "\346\212\245\345\221\212/\345\271\264\345\272\246..."

# quotepath=false — 正常
D       报告/年度总结报告.md
```

`i18n.logOutputEncoding` 只影响编码转换，不影响路径引用。

## 修复

在所有通过 `GitExecutor` 执行的 git 命令中添加 `-c core.quotepath=false`，与已有的 `-c i18n.logOutputEncoding=utf-8` 并列。

影响的命令：
- `git diff --name-status` — 文件变更列表
- `git diff --numstat` — 增删行数统计
- `git show --name-status` — commit 详情文件变更
- `git status --porcelain` — 未提交变更

## 改动文件

`src/gitHistory/service/gitExecutor.ts` — 在 spawn 参数中添加 `-c core.quotepath=false`

## 测试方法

### 1. 创建测试仓库

```bash
mkdir test-encoding && cd test-encoding && git init
mkdir 文档 报告
echo hello > 文档/readme.txt
echo 内容 > 文档/说明文档.txt
echo test > 报告/年度总结报告.md
git add . && git commit -m "Initial"
echo modify >> 文档/说明文档.txt
mkdir -p 项目/源代码 项目/文档
echo content > 项目/源代码/main.ts
echo doc > 项目/文档/需求分析.md
rm 普通文件.txt
mv 报告/年度总结报告.md 报告/年度报告v2.md
git add . && git commit -m "Second"
```

### 2. 验证

打开该仓库 → 打开任意文件 → 右键 → Git History → 点击 commit → 查看 diff 面板中文件路径是否正常显示中文。