### PR TITLE
feat(markdown): add leadingSlashAsWorkspaceRoot option for image path…

### DIFF
--- a/package.json
+++ b/package.json
@@ -669,6 +669,11 @@
 						"default": false,
 						"description": "Using workspace path as markdown image base path."
 					},
+					"vscode-office.leadingSlashAsWorkspaceRoot": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Treat image paths starting with '/' as relative to the workspace root directory, matching VS Code's built-in markdown preview behavior."
+					},
 					"vscode-office.pasterImgPath": {
 						"type": "string",
 						"default": "image/${fileName}/${now}.${ext}",
@@ -833,7 +838,6 @@
 		"vite-plugin-static-copy": "^4.1.1"
 	},
 	"dependencies": {
-		"7z-wasm": "^1.2.0",
 		"@ant-design/icons": "^5.3.5",
 		"@codemirror/autocomplete": "^6.20.3",
 		"@codemirror/commands": "^6.10.3",
@@ -849,6 +853,7 @@
 		"@vscode/codicons": "^0.0.45",
 		"@vscode/extension-telemetry": "^1.5.2",
 		"@zip.js/zip.js": "^2.8.26",
+		"7z-wasm": "^1.2.0",
 		"ag-psd": "^30.1.1",
 		"antd": "^5.15.4",
 		"axios": "^1.18.1",
@@ -901,6 +906,7 @@
 		"tar": "^7.5.16",
 		"udsv": "^0.5.3",
 		"utif": "^3.1.0",
+		"vsce": "^2.15.0",
 		"vscode-html-to-docx": "^1.1.3",
 		"xlsx": "^0.18.5",
 		"yaml": "^2.9.0"

--- a/resource/markdown/index.js
+++ b/resource/markdown/index.js
@@ -2,10 +2,10 @@ import { getToolbar, bindShortcut, createContextMenu, setAIAvailable } from "./u
 import { mapVscodeLanguageToVditorLang } from "./lang.js";
 
 handler.on("open", async (md) => {
-  const { content, rootPath, documentCacheId, pendingFragment, config } = md;
+  const { content, rootPath, documentCacheId, pendingFragment, config, workspaceRootUri } = md;
   const {
     language, isWeb, isDev, markdown,
-    editMode, editorTheme, codeMirrorTheme, mermaidTheme
+    editMode, editorTheme, codeMirrorTheme, mermaidTheme, leadingSlashAsWorkspaceRoot
   } = config;
   if (isWeb) {
     document.body.classList.add('is-web')
@@ -121,6 +121,37 @@ handler.on("open", async (md) => {
           editor.applyViewerSettings(viewerSettings.settings);
         }
       }
+
+      // Fix absolute image paths: rewrite /images/foo.png to workspace root
+      if (leadingSlashAsWorkspaceRoot && workspaceRootUri) {
+        const fixImageSrc = (img) => {
+          const attrSrc = img.getAttribute('src');
+          if (attrSrc && attrSrc.startsWith('/') && !attrSrc.startsWith('//')) {
+            // Set the .src property (not attribute) so the browser loads from the workspace root URI.
+            // The attribute stays as /images/foo.png for markdown conversion to preserve original source.
+            img.src = workspaceRootUri.replace(/\/$/, '') + attrSrc;
+          }
+        };
+
+        // Fix existing images
+        document.querySelectorAll('img[src^="/"]').forEach(fixImageSrc);
+
+        // Watch for dynamically added images
+        const imgObserver = new MutationObserver((mutations) => {
+          for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+              if (node.nodeType === Node.ELEMENT_NODE) {
+                if (node.tagName === 'IMG') {
+                  fixImageSrc(node);
+                }
+                node.querySelectorAll?.('img[src^="/"]').forEach(fixImageSrc);
+              }
+            }
+          }
+        });
+        imgObserver.observe(document.body, { childList: true, subtree: true });
+      }
+
       handler.on('viewerSettingsSync', ({ enabled }) => {
         editor.setViewerSettingsSyncEnabled(!!enabled);
       });

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -197,11 +197,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         });
         handler.on("init", async () => {
             const viewerSettings = await ViewerSettingsService.loadForWebview();
+            const workspaceRootPath = getWorkspacePath(folderPath);
+            const workspaceRootUri = webview.asWebviewUri(vscode.Uri.file(workspaceRootPath)).toString()
+                .replace(/\?.+$/, '').replace('https://git', 'https://file');
             handler.emit("open", {
                 content, rootPath,
                 documentCacheId: `${uri.scheme}:${uri.toString()}`,
                 pendingFragment: consumePendingBlockScroll(uri),
                 config: this.getMarkdownWebviewConfig(config),
+                workspaceRootUri,
                 viewerSettings,
             })
             this.updateCount(content)
@@ -471,6 +475,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             editorTheme: configuration.get<string>("editorTheme", "Auto"),
             codeMirrorTheme: configuration.get<string>("codeMirrorTheme", "Auto"),
             mermaidTheme: configuration.get<string>("mermaidTheme", "Auto"),
+            leadingSlashAsWorkspaceRoot: configuration.get<boolean>("leadingSlashAsWorkspaceRoot", false),
             markdown: {
                 math: {
                     macros: markdownConfiguration.get<Record<string, string>>("math.macros", {}),


### PR DESCRIPTION
When enabled, image paths starting with a single "/" (e.g., /images/foo.png) are resolved relative to the workspace root directory, matching VS Code's built-in markdown preview behavior.