### PR TITLE
fix: render wikilinks in YAML frontmatter

### DIFF
--- a/vditor/src/ts/codeBlock/codeMirrorManager.ts
+++ b/vditor/src/ts/codeBlock/codeMirrorManager.ts
@@ -33,6 +33,7 @@ import {
 } from "../math/inlineMathCodeMirror";
 import {
     flushFrontMatterYamlToSyncCode,
+    renderFrontMatterWikiLinksInScope,
 } from "./frontMatterEditor";
 
 export { focusCodeBlockChromeLanguage, isInsideCodeBlockChrome } from "./codeBlockChrome";
@@ -1395,6 +1396,7 @@ export const deactivateCodeMirrorsInScope = (vditor: IVditor, scope: HTMLElement
 
 /** Spin 后仅重建作用域内需要编辑的 CodeMirror */
 export const renderCodeBlocksInScope = (vditor: IVditor, scope: HTMLElement) => {
+    renderFrontMatterWikiLinksInScope(scope);
     for (const blockElement of collectCodeBlocksInScope(vditor, scope)) {
         scheduleLazyCodeBlock(vditor, blockElement);
     }
@@ -1654,6 +1656,7 @@ export const renderCodeBlocks = (vditor: IVditor) => {
     if (!editor) {
         return;
     }
+    renderFrontMatterWikiLinksInScope(editor);
     for (const block of editor.querySelectorAll(getCodeBlockSelector(vditor.currentMode))) {
         scheduleLazyCodeBlock(vditor, block as HTMLElement);
     }

--- a/vditor/src/ts/codeBlock/frontMatterEditor.ts
+++ b/vditor/src/ts/codeBlock/frontMatterEditor.ts
@@ -11,6 +11,8 @@ import { afterRenderEvent } from "../wysiwyg/afterRenderEvent";
 
 const FRONT_MATTER_POPOVER_CLASS = "vditor-popover--front-matter";
 const FRONT_MATTER_PANEL_CLASS = "vditor-panel--front-matter";
+const FRONT_MATTER_VALUE_SELECTOR = "[data-type='yaml-front-matter'] .vditor-properties__value";
+const FRONT_MATTER_WIKILINK_PATTERN = /\[\[([^\[\]\n]+?)\]\]/g;
 const POPOVER_INSET = 8;
 const VIEWPORT_MARGIN = 12;
 
@@ -33,6 +35,74 @@ const getModeEditor = (vditor: IVditor) => {
         return vditor.ir.element;
     }
     return null;
+};
+
+const parseFrontMatterWikiLink = (raw: string) => {
+    const pipeIndex = raw.indexOf("|");
+    const href = (pipeIndex < 0 ? raw : raw.slice(0, pipeIndex)).trim();
+    const alias = pipeIndex < 0 ? "" : raw.slice(pipeIndex + 1).trim();
+    if (!href) {
+        return null;
+    }
+    return { href, text: alias || href };
+};
+
+const renderWikiLinksInTextNode = (textNode: Text) => {
+    const source = textNode.nodeValue || "";
+    FRONT_MATTER_WIKILINK_PATTERN.lastIndex = 0;
+    if (!FRONT_MATTER_WIKILINK_PATTERN.test(source)) {
+        return;
+    }
+
+    FRONT_MATTER_WIKILINK_PATTERN.lastIndex = 0;
+    const fragment = document.createDocumentFragment();
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = FRONT_MATTER_WIKILINK_PATTERN.exec(source)) !== null) {
+        if (match.index > lastIndex) {
+            fragment.appendChild(document.createTextNode(source.slice(lastIndex, match.index)));
+        }
+        const parsed = parseFrontMatterWikiLink(match[1]);
+        if (!parsed) {
+            fragment.appendChild(document.createTextNode(match[0]));
+        } else {
+            const link = document.createElement("a");
+            link.className = "obsidian-wikilink";
+            link.dataset.href = parsed.href;
+            link.href = "#";
+            link.textContent = parsed.text;
+            fragment.appendChild(link);
+        }
+        lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < source.length) {
+        fragment.appendChild(document.createTextNode(source.slice(lastIndex)));
+    }
+    textNode.replaceWith(fragment);
+};
+
+export const renderFrontMatterWikiLinksInScope = (scope: HTMLElement) => {
+    const valueElements: HTMLElement[] = [];
+    if (scope.matches(FRONT_MATTER_VALUE_SELECTOR)) {
+        valueElements.push(scope);
+    }
+    scope.querySelectorAll(FRONT_MATTER_VALUE_SELECTOR).forEach((element) => {
+        valueElements.push(element as HTMLElement);
+    });
+
+    for (const valueElement of valueElements) {
+        const textNodes: Text[] = [];
+        const walker = document.createTreeWalker(valueElement, NodeFilter.SHOW_TEXT);
+        let node = walker.nextNode();
+        while (node) {
+            const parent = node.parentElement;
+            if (parent && !parent.closest(".obsidian-wikilink, .obsidian-wikilink-embed")) {
+                textNodes.push(node as Text);
+            }
+            node = walker.nextNode();
+        }
+        textNodes.forEach(renderWikiLinksInTextNode);
+    }
 };
 
 const getYamlSourceFromBlock = (blockElement: HTMLElement) => {


### PR DESCRIPTION
## Summary

- render Obsidian-style wikilinks inside YAML frontmatter property values
- support `[[target]]`, `[[target|label]]`, and multiple links mixed with plain text
- reuse the existing wikilink click handling while preserving the original YAML source

## Root cause

The frontmatter property panel rendered most YAML values as escaped plain text. The editor already knew how to open elements with the `obsidian-wikilink` class and `data-href`, but those elements were never created for links embedded in ordinary frontmatter properties.

## User impact

Links such as `year: "[[2026]]"` and `type: "[[Note quotidienne]]"` now display and behave like wikilinks in both WYSIWYG and IR modes. Rendering is idempotent, and serializing the document still returns the original YAML rather than the generated link markup.

## Validation

- `npm run build --prefix vditor`
- `npm run build`
- Playwright verification in WYSIWYG and IR modes for plain links, aliases, multiple links, click payloads, and Markdown round-tripping

Fixes #542
